### PR TITLE
System Types and Process Ordering on EntitySytems and SystemManager.

### DIFF
--- a/Artemis.csproj
+++ b/Artemis.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/EntitySystem.cs
+++ b/EntitySystem.cs
@@ -6,6 +6,9 @@ namespace Artemis
 		private long systemBit = 0;
 	
 		private long typeFlags = 0;
+
+        private SystemType systemType = SystemType.Update;
+        private int processOrder;
 		
 		protected bool enabled = true;
 	
@@ -15,6 +18,11 @@ namespace Artemis
 		
 		public EntitySystem() {
 		}
+
+	    public EntitySystem(SystemType systemType)
+	    {
+	        this.systemType = systemType;
+	    }
 	
 		public EntitySystem(params Type[] types) {
 			for (int i = 0, j = types.Length; i < j; i++) {
@@ -27,6 +35,23 @@ namespace Artemis
 		public void SetSystemBit(long bit) {
 			this.systemBit = bit;
 		}
+
+        public SystemType GetSystemType(){
+            return systemType;
+        }
+
+        public void SetSystemType(SystemType systemType){
+            this.systemType = systemType;
+        }
+
+        public int GetProcessOrder(){
+            return processOrder;
+        }
+
+        public void SetProcessOrder(int processOrder){
+            this.processOrder = processOrder;
+        }
+
 		
 		/**
 		 * Called before processing of entities begins. 

--- a/SystemManager.cs
+++ b/SystemManager.cs
@@ -1,47 +1,84 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
 namespace Artemis
 {
-	public sealed class SystemManager {
-		private World world;
-		private Dictionary<Type, EntitySystem> systems = new Dictionary<Type, EntitySystem>();
-		private Bag<EntitySystem> bagged = new Bag<EntitySystem>();
-		
-		public SystemManager(World world) {
-			this.world = world;
-		}
-		
-		public T SetSystem<T>(T system) where T : EntitySystem {
-			system.SetWorld(world);
-			
-			systems.Add(typeof(T), (EntitySystem)system);
-			
-			if(!bagged.Contains((EntitySystem)system))
-				bagged.Add((EntitySystem)system);
-			
-			system.SetSystemBit(SystemBitManager.GetBitFor(system));
-			
-			return (T)system;
-		}
-		
-		public T GetSystem<T>() where T : EntitySystem {
+    public sealed class SystemManager {
+        private World world;
+        private Dictionary<Type, EntitySystem> systems = new Dictionary<Type, EntitySystem>();
+        private Bag<EntitySystem> bagged = new Bag<EntitySystem>();
+
+        
+        public SystemManager(World world) {
+            this.world = world;
+        }
+
+
+        public T SetSystem<T>(T system, SystemType systemType, int processOrder) where T : EntitySystem{
+            system.SetProcessOrder(processOrder);
+            system.SetSystemType(systemType);
+
+            return SetSystem(system);
+        }
+
+        public T SetSystem<T>(T system, SystemType systemType) where T : EntitySystem{
+            int processOrder = bagged.Size();
+
+            return SetSystem(system, systemType, processOrder);
+        }
+
+        public T SetSystem<T>(T system) where T : EntitySystem {
+            system.SetWorld(world);
+            
+            systems.Add(typeof(T), system);
+            
+            if(!bagged.Contains(system))
+                bagged.Add(system);
+            
+            system.SetSystemBit(SystemBitManager.GetBitFor(system));
+            
+            return system;
+        }
+        
+        public T GetSystem<T>() where T : EntitySystem {
             EntitySystem system;
             systems.TryGetValue(typeof(T), out system);
-			return (T)system;
-		}
-		
-		public Bag<EntitySystem> GetSystems() {
-			return bagged;
-		}
-		
-		/**
-		 * After adding all systems to the world, you must initialize them all.
-		 */
-		public void InitializeAll() {
-		   for (int i = 0, j = bagged.Size(); i < j; i++) {
-		      bagged.Get(i).Initialize();
-		   }
-		} 
-	
-	}
+            return (T)system;
+        }
+        
+        public Bag<EntitySystem> GetSystems() {
+            return bagged;
+        }
+        
+        /**
+         * After adding all systems to the world, you must initialize them all.
+         */
+        public void InitializeAll() {
+           for (int i = 0, j = bagged.Size(); i < j; i++) {
+              bagged.Get(i).Initialize();
+           }
+        } 
+    
+        public void ProcessSystemsForSystemType(SystemType type)
+        {
+            foreach (var system in systems.Values.Where(s=>s.GetSystemType() == type).OrderBy(s=>s.GetProcessOrder())){
+                system.Process();
+            }
+        }
+
+        public void ProcessAll()
+        {
+            for (int i = 0, j = bagged.Size(); i < j; i++)
+            {
+                bagged.Get(i).Process();
+            }
+        }
+    }
+
+    public enum SystemType
+    {
+        Render,
+        Update
+    }
 }


### PR DESCRIPTION
Just added some overload methods to allow the base game class to process all the Update and Render systems in specific calls without knowing what the systems were.   The systems can be registered to systemtypes and/or process orders so we can process specific types (right now just set as Render and Update), and also can be set to run in a specific order.  

Added some extra processing methods to the SystemManager.  To help with processing only the systems for rendering or update systems.  Also included processing the systems in specific orders.  Included the ability to run all of the systems 

Added  ProcessOrder and SystemType Getters and Setters on Entity System.

Added SystemType enum that we can use to process only specific processes if wanted.  
