### PR TITLE
Fixed a bug in EntityManager.GetEntities

### DIFF
--- a/Artemis_XNA_INDEPENDENT/Manager/EntityManager.cs
+++ b/Artemis_XNA_INDEPENDENT/Manager/EntityManager.cs
@@ -187,7 +187,7 @@ namespace Artemis.Manager
             for (int index = 0; index < this.ActiveEntities.Count; ++index)
             {
                 Entity entity = this.ActiveEntities.Get(index);
-                if (aspect.Interests(entity))
+                if (entity != null && aspect.Interests(entity))
                 {
                     entitiesBag.Add(entity);
                 }


### PR DESCRIPTION
If Entities were removed, the slot in ActiveEntities would contain null until reused by a newly created Entity.  In such cases a NullReferenceException was occurring when ActiveEntities was inspected for entities matching the requested aspect.  Empty slots are now ignored.
