### PR TITLE
Add component from pool to entity after running init code

### DIFF
--- a/Artemis_XNA_INDEPENDENT/Entity.cs
+++ b/Artemis_XNA_INDEPENDENT/Entity.cs
@@ -229,6 +229,18 @@ namespace Artemis
             return (T)component;
         }
 
+        /// <summary>Gets the component from pool, runs init delegate, then adds the components to the entity.</summary>
+        /// <typeparam name="T">The <see langword="Type"/> T.</typeparam>
+        /// <returns>The added component.</returns>
+        public void AddComponentFromPool<T>(global::System.Action<T> init) where T : ComponentPoolable
+        {
+            Debug.Assert(init != null, "Init delegate must not be null.");
+
+            T component = this.entityWorld.GetComponentFromPool<T>();
+            init(component);
+            this.entityManager.AddComponent<T>(this, component);
+        }
+
         /// <summary>Deletes this instance.</summary>
         public void Delete()
         {


### PR DESCRIPTION
## Problem

Since Entity is automatically refreshed after adding a Component, the respective Systems run their `OnAdded(Entity entity)` methods during `entity.AddComponent` call.
It's all good when you first create a component, initialize all the required data - and only then _AddComponent_.
But `Entity.AddComponentFromPool<T>()` does not allow you to 1) get component from pool; 2) set component's data; 3) add component to entity. It just adds a newly created or (possibly) cleaned-up Component to Entity. Thus Systems may get an Entity with inconsistent Component data in `EnitySystem.OnAdded(Entity entity)` method.

Remember issue #49 where `EntitySystem.OnRemoved` was expected to unload some resource - that was supposed to be previousely loaded in OnAdded event.
## Solution

``` csharp
public void AddComponentFromPool<T>(global::System.Action<T> init) where T : ComponentPoolable
{
    Debug.Assert(init != null, "Init delegate must not be null.");

    T component = this.entityWorld.GetComponentFromPool<T>();
    init(component);
    this.entityManager.AddComponent<T>(this, component);
}
```

Example:

``` csharp
entity.AddComponentFromPool<TestPowerComponentPoolable>(c => c.Power = 100);
```

vs old workaround

``` csharp
var c = this.EntityWorld.GetComponentFromPool(typeof(TestPowerComponentPoolable));
c.Power = 100;
entity.AddComponent(c);
```

Both approaches are good, but it is good to see all the possibilities after typing `entity.`
