### PR TITLE
Made SystemBitManager instanced

### DIFF
--- a/Artemis_XNA_INDEPENDENT/Manager/SystemBitManager.cs
+++ b/Artemis_XNA_INDEPENDENT/Manager/SystemBitManager.cs
@@ -51,29 +51,29 @@ namespace Artemis.Manager
     #endregion Using statements
 
     /// <summary>Class SystemBitManager.</summary>
-    internal static class SystemBitManager
+    internal class SystemBitManager
     {
         /// <summary>The system bits.</summary>
-        private static readonly Dictionary<EntitySystem, BigInteger> SystemBits = new Dictionary<EntitySystem, BigInteger>();
+        private readonly Dictionary<EntitySystem, BigInteger> systemBits = new Dictionary<EntitySystem, BigInteger>();
 
         /// <summary>The position.</summary>
-        private static int position;
+        private int position;
 
         /// <summary>Gets the bit-register for the specified entity system.</summary>
         /// <param name="entitySystem">The entity system.</param>
         /// <returns>The bit flag register for the specified system.</returns>
-        public static BigInteger GetBitFor(EntitySystem entitySystem)
+        public BigInteger GetBitFor(EntitySystem entitySystem)
         {
             BigInteger bit;
-            if (SystemBits.TryGetValue(entitySystem, out bit) == false)
+            if (this.systemBits.TryGetValue(entitySystem, out bit) == false)
             {
 #if WINDOWS_PHONE || XBOX || PORTABLE || FORCEINT32
-                bit = 1 << position;
+                bit = 1 << this.position;
 #else
-                bit = 1L << position;
+                bit = 1L << this.position;
 #endif
-                ++position;
-                SystemBits.Add(entitySystem, bit);
+                this.position++;
+                this.systemBits.Add(entitySystem, bit);
             }
 
             return bit;

--- a/Artemis_XNA_INDEPENDENT/Manager/SystemManager.cs
+++ b/Artemis_XNA_INDEPENDENT/Manager/SystemManager.cs
@@ -69,6 +69,9 @@ namespace Artemis.Manager
         /// <summary>The systems.</summary>
         private readonly IDictionary<Type, IList> systems;
 
+        /// <summary>The systemBitManager.</summary>
+        private readonly SystemBitManager systemBitManager;
+
         /// <summary>The merged bag.</summary>
         private readonly Bag<EntitySystem> mergedBag;
 
@@ -90,6 +93,7 @@ namespace Artemis.Manager
             this.drawLayers = new Dictionary<int, SystemLayer>();
             this.updateLayers = new Dictionary<int, SystemLayer>();                
 #endif
+            this.systemBitManager = new SystemBitManager();
             this.systems = new Dictionary<Type, IList>();
             this.entityWorld = entityWorld;
         }
@@ -412,7 +416,7 @@ namespace Artemis.Manager
                 this.mergedBag.Add(system);
             }
 
-            system.SystemBit = SystemBitManager.GetBitFor(system);
+            system.SystemBit = this.systemBitManager.GetBitFor(system);
 
             return system;
         }


### PR DESCRIPTION
Changed SystemBitManager usage from static to instanced:
- solves a multithreading issue when several EntityWorlds are
  concurrently initialized;
- solves an issue when every next EntityWorld created gets its System's
  SystemBit starting not from 0, but from the last bit of the System of
  the previous world (i. e. SystemBit value gradually increases between
  worlds).

I did not thoroughly reviewed implementation dependencies of using an instance of EntitySystem instead of it's Type as a key: though ComponentType system works with Types, not instances.

Also the whole SystemBitManager class can probably be merged into SystemManager for simplicity.
