### PR TITLE
Got rid of double Refresh when deleting Entity

### DIFF
--- a/Artemis_XNA_INDEPENDENT/Manager/EntityManager.cs
+++ b/Artemis_XNA_INDEPENDENT/Manager/EntityManager.cs
@@ -232,11 +232,6 @@ namespace Artemis.Manager
             Debug.Assert(entity != null, "Entity must not be null.");
 
             this.ActiveEntities.Set(entity.Id, null);
-
-            entity.TypeBits = 0;
-
-            this.Refresh(entity);
-
             this.RemoveComponentsOfEntity(entity);
 #if DEBUG
             --this.EntitiesRequestedCount;
@@ -394,6 +389,9 @@ namespace Artemis.Manager
         internal void RemoveComponentsOfEntity(Entity entity)
         {
             Debug.Assert(entity != null, "Entity must not be null.");
+
+            entity.TypeBits = 0;
+            this.Refresh(entity);
             
             int entityId = entity.Id;
             for (int index = this.componentsByType.Count - 1; index >= 0; --index)
@@ -410,8 +408,6 @@ namespace Artemis.Manager
                     components.Set(entityId, null);
                 }
             }
-
-			this.Refresh(entity);
         }
 
         /// <summary>Entities the manager removed component event.</summary>


### PR DESCRIPTION
When an entity was being removed from _EntityWorld_, `EntityManager.Remove(entity)` caused `Refresh(entity)` two times: once in _Remove_, once in _RemoveComponentsOfEntity_. This resulted in enumerating all Systems twice, removing Entity on first enumeration, pointlessly calculating _contains_ and _interest_ vars on second enumeration.

With the proposed changes it:
1) cleares TypeBits;
2) calls Refresh (triggers every Systems'.OnChange(entity))
3) nulls Components in Component containers

This change makes _RemoveComponent_ and _RemoveComponentsOfEntity_ behavior more consistent (and still conforming to the issue pointed out in #49)
