### PR TITLE
Update Aspect to prevent runtime error

### DIFF
--- a/Artemis_XNA_INDEPENDENT/Aspect.cs
+++ b/Artemis_XNA_INDEPENDENT/Aspect.cs
@@ -113,7 +113,7 @@ namespace Artemis
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise</returns>
         public virtual bool Interests(Entity entity)
         {
-            if (!(this.ContainsTypesMap > 0 || this.ExcludeTypesMap > 0 || this.OneTypesMap > 0))
+            if (!(this.ContainsTypesMap > 0 || this.ExcludeTypesMap > 0 || this.OneTypesMap > 0) || entity == null)
             {
                 return false;
             }


### PR DESCRIPTION
I had a runtime error when using this.EntityWorld.EntityManager.GetEntities(Aspect aspect) due to null entities which can be also found in EntityManagers ActiveEntities
