### PR TITLE
RemoveComponent deferred until the update, fixes bug introduced in #64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 # Build results
 [Dd]ebug/
 [Rr]elease/
+# Roslyn cache directories
+*.ide/
 *_i.c
 *_p.c
 *.ilk

--- a/Artemis_UnitTests/TestGeneral.cs
+++ b/Artemis_UnitTests/TestGeneral.cs
@@ -845,6 +845,7 @@ namespace UnitTests
             Assert.AreEqual(expectedPower, entity.GetComponent<TestPowerComponentPoolable>().Power);
 
             entity.RemoveComponent<TestPowerComponentPoolable>();
+            entityWorld.Update();
             Assert.IsFalse(entity.HasComponent<TestPowerComponentPoolable>());
 
             expectedPower = 100;
@@ -854,16 +855,24 @@ namespace UnitTests
             Assert.AreEqual(expectedPower, entity.GetComponent<TestPowerComponentPoolable>().Power);
 
             entity.RemoveComponent<TestPowerComponentPoolable>();
+            entityWorld.Update();
             Assert.IsFalse(entity.HasComponent<TestPowerComponentPoolable>());
 
             entityWorld.EntityManager.AddedComponentEvent -= addedComponentEventHandler;
 
-            Debug.WriteLine("Causing ComponentPool<TestPowerComponentPoolable> to fill up to maximum capacity...");	
+            Debug.WriteLine("Causing ComponentPool<TestPowerComponentPoolable> to fill up to maximum capacity...");
 
+            var entities = new List<Entity>();
             while (pool.InvalidCount > 0)
             {
-                entity.AddComponentFromPool<TestPowerComponentPoolable>(c => c.Power = expectedPower);
-                entity.RemoveComponent<TestPowerComponentPoolable>();
+                var ent = entityWorld.CreateEntity();
+                ent.AddComponentFromPool<TestPowerComponentPoolable>(c => c.Power = expectedPower);
+                entities.Add(ent);
+            }
+
+            foreach (var ent in entities)
+            { 
+                ent.RemoveComponent<TestPowerComponentPoolable>();
             }
 
             Debug.WriteLine("Causing ComponentPool<TestPowerComponentPoolable> cleanup...");

--- a/Artemis_UnitTests/TestGeneral.cs
+++ b/Artemis_UnitTests/TestGeneral.cs
@@ -898,7 +898,13 @@ namespace UnitTests
 
             entity.AddComponent(new TestHealthComponent());
             entity.RemoveComponent<TestHealthComponent>();
-            Debug.WriteLine("OK");
+
+            // Removing component is deferred until the update
+            Assert.IsNotNull(entity.GetComponent<TestHealthComponent>());
+
+            // Update the world, component should be removed
+            entityWorld.Update();
+            Assert.IsNull(entity.GetComponent<TestHealthComponent>());
 
             // Remove absent component
             entity.RemoveComponent<TestHealthComponent>();

--- a/Artemis_XNA_INDEPENDENT/Entity.cs
+++ b/Artemis_XNA_INDEPENDENT/Entity.cs
@@ -298,14 +298,14 @@ namespace Artemis
             this.RefreshingState = true;
         }
 
-        /// <summary>Remove Component from this entity.</summary>
+        /// <summary>Marks the component to remove. The actual removal is deferred and will happen in the next EntityWorld update.</summary>
         /// <typeparam name="T">Component Type.</typeparam>
         public void RemoveComponent<T>() where T : IComponent
         {
             this.entityManager.RemoveComponent(this, ComponentTypeManager.GetTypeFor<T>());
         }
 
-        /// <summary><para>Removes the component.</para>
+        /// <summary><para>Marks the component to remove. The actual removal is deferred and will happen in the next EntityWorld update.</para>
         ///   <para>Faster removal of components from a entity.</para></summary>
         /// <param name="componentType">The type.</param>
         public void RemoveComponent(ComponentType componentType)

--- a/Artemis_XNA_INDEPENDENT/EntityWorld.cs
+++ b/Artemis_XNA_INDEPENDENT/EntityWorld.cs
@@ -354,6 +354,8 @@ namespace Artemis
                 }
             }
 
+            this.EntityManager.RemoveMarkedComponents();
+
             if (!this.deleted.IsEmpty)
             {
                 for (int index = this.deleted.Count - 1; index >= 0; --index)

--- a/Artemis_XNA_INDEPENDENT/EntityWorld.cs
+++ b/Artemis_XNA_INDEPENDENT/EntityWorld.cs
@@ -344,6 +344,8 @@ namespace Artemis
         {
             this.Delta = deltaTicks;
 
+            this.EntityManager.RemoveMarkedComponents();
+
             ++this.poolCleanupDelayCounter;
             if (this.poolCleanupDelayCounter > this.PoolCleanupDelay)
             {
@@ -353,8 +355,6 @@ namespace Artemis
                     this.pools[item].CleanUp();
                 }
             }
-
-            this.EntityManager.RemoveMarkedComponents();
 
             if (!this.deleted.IsEmpty)
             {

--- a/Artemis_XNA_INDEPENDENT/Manager/EntityManager.cs
+++ b/Artemis_XNA_INDEPENDENT/Manager/EntityManager.cs
@@ -53,9 +53,16 @@ namespace Artemis.Manager
     {
         /// <summary>The components by type.</summary>
         private readonly Bag<Bag<IComponent>> componentsByType;
-        
+
         /// <summary>The removed and available.</summary>
         private readonly Bag<Entity> removedAndAvailable;
+
+        /// <summary>Components to be removed in the next update</summary>
+#if XBOX || WINDOWS_PHONE || PORTABLE
+   		private readonly Bag<Tuple<Entity, ComponentType>> componentsToBeRemoved = new Bag<Tuple<Entity, ComponentType>>();
+#else
+        private readonly HashSet<Tuple<Entity, ComponentType>> componentsToBeRemoved = new HashSet<Tuple<Entity, ComponentType>>();
+#endif
 
         /// <summary>Map unique id to entities</summary>
         private readonly Dictionary<long, Entity> uniqueIdToEntities;
@@ -160,7 +167,7 @@ namespace Artemis.Manager
         {
             Debug.Assert(entity != null, "Entity must not be null.");
 
-            Bag<IComponent> entityComponents = new Bag<IComponent>();            
+            Bag<IComponent> entityComponents = new Bag<IComponent>();
             int entityId = entity.Id;
             for (int index = 0, b = this.componentsByType.Count; b > index; ++index)
             {
@@ -329,7 +336,7 @@ namespace Artemis.Manager
             }
 
             int entityId = entity.Id;
-            Bag<IComponent> bag = this.componentsByType.Get(componentType.Id);            
+            Bag<IComponent> bag = this.componentsByType.Get(componentType.Id);
 
             if (bag != null && entityId < bag.Capacity)
             {
@@ -366,24 +373,51 @@ namespace Artemis.Manager
         {
             Debug.Assert(entity != null, "Entity must not be null.");
             Debug.Assert(componentType != null, "Component type must not be null.");
-        
-            int entityId = entity.Id;
-            Bag<IComponent> components = this.componentsByType.Get(componentType.Id);
-        
-            if (components != null && entityId < components.Count)
+
+            var pair = new Tuple<Entity, ComponentType>(entity, componentType);
+#if XBOX || WINDOWS_PHONE || PORTABLE
+            if (!this.componentsToBeRemoved.Contains(pair))
             {
-                IComponent componentToBeRemoved = components.Get(entityId);
-                if (this.RemovedComponentEvent != null && componentToBeRemoved != null)
-                {
-                    this.RemovedComponentEvent(entity, componentToBeRemoved);
-                }
-        
-                entity.RemoveTypeBit(componentType.Bit);
-                this.entityWorld.RefreshEntity(entity);
-                components.Set(entityId, null);
+                this.componentsToBeRemoved.Add(pair);
             }
+#else
+            this.componentsToBeRemoved.Add(pair);
+#endif
         }
-        
+
+        /// <summary>Removes components marked for removal</summary>
+        internal void RemoveMarkedComponents()
+        {
+#if XBOX || WINDOWS_PHONE || PORTABLE
+            for (int index = this.componentsToBeRemoved.Count - 1; index >= 0; --index)
+            {
+                var pair = this.componentsToBeRemoved.Get(index);
+#else
+            foreach (var pair in this.componentsToBeRemoved)
+            {
+#endif
+                var entity = pair.Item1;
+                var componentType = pair.Item2;
+
+                int entityId = entity.Id;
+                Bag<IComponent> components = this.componentsByType.Get(componentType.Id);
+
+                if (components != null && entityId < components.Count)
+                {
+                    IComponent componentToBeRemoved = components.Get(entityId);
+                    if (this.RemovedComponentEvent != null && componentToBeRemoved != null)
+                    {
+                        this.RemovedComponentEvent(entity, componentToBeRemoved);
+                    }
+
+                    entity.RemoveTypeBit(componentType.Bit);
+                    this.entityWorld.RefreshEntity(entity);
+                    components.Set(entityId, null);
+                }
+            }
+            this.componentsToBeRemoved.Clear();
+        }
+
         /// <summary>Strips all components from the given entity.</summary>
         /// <param name="entity">Entity for which you want to remove all components</param>
         internal void RemoveComponentsOfEntity(Entity entity)
@@ -392,7 +426,7 @@ namespace Artemis.Manager
 
             entity.TypeBits = 0;
             this.entityWorld.RefreshEntity(entity);
-            
+
             int entityId = entity.Id;
             for (int index = this.componentsByType.Count - 1; index >= 0; --index)
             {


### PR DESCRIPTION
Test for removing component is updated and passing. I also updated .gitignore to include Roslyn cache.
I found some errors in the store and portable version, tests are not compiling because of the new Reflection API. I have updated them as well, but it's not included in this PR.