### PR TITLE
Fix Aspect Exclude to handle multiple types correctly

### DIFF
--- a/Artemis_XNA_INDEPENDENT/Aspect.cs
+++ b/Artemis_XNA_INDEPENDENT/Aspect.cs
@@ -131,7 +131,7 @@ namespace Artemis
 
             return ((this.OneTypesMap      & entity.TypeBits) != 0                     || this.OneTypesMap      == 0) &&
                    ((this.ContainsTypesMap & entity.TypeBits) == this.ContainsTypesMap || this.ContainsTypesMap == 0) &&
-                   ((this.ExcludeTypesMap  & entity.TypeBits) != this.ExcludeTypesMap  || this.ExcludeTypesMap  == 0);
+                   ((this.ExcludeTypesMap  & entity.TypeBits) == 0                     || this.ExcludeTypesMap  == 0);
         }
 
         /// <summary>Gets all.</summary>


### PR DESCRIPTION
Systems with an Aspect using multiple Exclude types were previously picking up entities that should have been excluded in scenarios where the entity didn't have all the components listed in the Exclude.

The Interests method was specifically testing if _all_ excluded component types were on the entity.
Fixed so that it tests whether _any_ excluded component type is on the entity.
Tested with various combinations of components.

I wrote a unit test but I haven't included it as it meant adding a new system with a multiple-exclude aspect to the unit tests, leading to changes in multiple project files which I wasn't able to test build on my system. If you want me to add that code let me know and I can add commits or put it on a separate pull request for you to test-build yourself.
