### PR TITLE
Partial fixed for issue #90

### DIFF
--- a/Artemis_XNA_INDEPENDENT/EntityWorld.cs
+++ b/Artemis_XNA_INDEPENDENT/EntityWorld.cs
@@ -386,6 +386,7 @@ namespace Artemis
                     Entity entity = this.refreshed.Get(index);
                     this.EntityManager.Refresh(entity);
                     entity.RefreshingState = false;
+                    this.refreshed.Remove(index);
                 }
 #else
                 foreach (Entity entity in this.refreshed)
@@ -394,8 +395,8 @@ namespace Artemis
                     entity.RefreshingState = false;
                 }
 
-#endif
                 this.refreshed.Clear();
+#endif
             }
 
             this.SystemManager.Update();


### PR DESCRIPTION
Fixed issue with entities refreshing not working properly if you add to the refresh list while the entity world is currently refreshing. Note that the foreach loop will actually still throw an exception.